### PR TITLE
Remove bug tracker

### DIFF
--- a/datafit/CHANGELOG.md
+++ b/datafit/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.5
 
 - Remove bug tracker (automatically populated by repository field)
+- Bump up `smath` dependency to 1.1.2
 
 ## 1.0.4
 

--- a/datafit/CHANGELOG.md
+++ b/datafit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+- Remove bug tracker (automatically populated by repository field)
+
 ## 1.0.4
 
 - Clean up `package.json`

--- a/datafit/package.json
+++ b/datafit/package.json
@@ -44,10 +44,6 @@
     "type": "paypal",
     "url": "https://www.paypal.com/donate/?business=UM6EEKPW8GXA2&no_recurring=0&item_name=Open+source+development&currency_code=USD"
   },
-  "bugs": {
-    "url": "https://github.com/nicfv/npm/issues",
-    "email": "npm@nicolasventura.com"
-  },
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {

--- a/datafit/package.json
+++ b/datafit/package.json
@@ -47,7 +47,7 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.1.1"
+    "smath": "1.1.2"
   },
   "devDependencies": {
     "typedoc": "0.25.11",

--- a/datafit/package.json
+++ b/datafit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datafit",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Simple curve-fitting algorithm",
   "homepage": "https://npm.nicfv.com/datafit",
   "main": "dist/index.js",

--- a/smath/CHANGELOG.md
+++ b/smath/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.3
+
+- Remove bug tracker (automatically populated by repository field)
+
 ## 1.1.2
 
 - Clean up `package.json`

--- a/smath/package.json
+++ b/smath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smath",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Small math function library",
   "homepage": "https://npm.nicfv.com/smath",
   "main": "dist/index.js",

--- a/smath/package.json
+++ b/smath/package.json
@@ -38,10 +38,6 @@
     "type": "paypal",
     "url": "https://www.paypal.com/donate/?business=UM6EEKPW8GXA2&no_recurring=0&item_name=Open+source+development&currency_code=USD"
   },
-  "bugs": {
-    "url": "https://github.com/nicfv/npm/issues",
-    "email": "npm@nicolasventura.com"
-  },
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "devDependencies": {

--- a/viridis/CHANGELOG.md
+++ b/viridis/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.6
 
 - Remove bug tracker (automatically populated by repository field)
+- Bump up `smath` dependency to 1.1.2
 
 ## 1.0.5
 

--- a/viridis/CHANGELOG.md
+++ b/viridis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6
+
+- Remove bug tracker (automatically populated by repository field)
+
 ## 1.0.5
 
 - Clean up `package.json`

--- a/viridis/package.json
+++ b/viridis/package.json
@@ -39,10 +39,6 @@
     "type": "paypal",
     "url": "https://www.paypal.com/donate/?business=UM6EEKPW8GXA2&no_recurring=0&item_name=Open+source+development&currency_code=USD"
   },
-  "bugs": {
-    "url": "https://github.com/nicfv/npm/issues",
-    "email": "npm@nicolasventura.com"
-  },
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {

--- a/viridis/package.json
+++ b/viridis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viridis",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Generate data visualization color gradients",
   "homepage": "https://npm.nicfv.com/viridis",
   "main": "dist/index.js",

--- a/viridis/package.json
+++ b/viridis/package.json
@@ -42,7 +42,7 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.1.1"
+    "smath": "1.1.2"
   },
   "devDependencies": {
     "typedoc": "0.25.11",


### PR DESCRIPTION
Turns out, the bug tracker in `package.json` is just dead weight. It's automatically populated if you include the `repository` field.

Also, take the opportunity to bump up the `smath` dependency version.