### PR TITLE
Include template readme in npm

### DIFF
--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -78,7 +78,7 @@ for dir in */ ; do
         echo 'Generating documentation...'
         npm run docs || exit 1
         mv docs "../.docs/${dir}"
-        # Reset the readme file to the default
+        # Reset the readme file to its original state
         echo "${readme}" > README.md
     fi
     cd ..

--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -52,15 +52,6 @@ for dir in */ ; do
     echo 'Running tests...'
     npm test || exit 1
     if "${publish}" ; then
-        # Determine latest published version on the registry
-        npm_version="$(npm --silent v "${package_name}" version)"
-        echo "Version on NPM = ${npm_version}"
-        if [[ "${local_version}" == "${npm_version}" ]] ; then
-            echo 'Skipping publish step'
-        else
-            echo 'Publishing...'
-            npm publish
-        fi
         # Store current readme content, copy over the
         # template readme file, and replace variables
         readme="$(cat README.md)"
@@ -71,6 +62,15 @@ for dir in */ ; do
         sed -i "s:%VER%:${local_version//':'/';'}:g" README.md
         sed -i "s:%TIME%:${package_date//':'/';'}:g" README.md
         echo "${readme}" >> README.md
+        # Determine latest published version on the registry
+        npm_version="$(npm --silent v "${package_name}" version)"
+        echo "Version on NPM = ${npm_version}"
+        if [[ "${local_version}" == "${npm_version}" ]] ; then
+            echo 'Skipping publish step'
+        else
+            echo 'Publishing...'
+            npm publish
+        fi
         # Always generate documentation because if only one
         # package generates documentation, then it will
         # overwrite the GH pages archive with that dir only

--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -54,6 +54,7 @@ for dir in */ ; do
     if "${publish}" ; then
         # Store current readme content, copy over the
         # template readme file, and replace variables
+        echo 'Generating readme...'
         readme="$(cat README.md)"
         cp '../.github/workflows/template.md' README.md
         sed -i "s:%NAME%:${package_name//':'/';'}:g" README.md
@@ -75,7 +76,7 @@ for dir in */ ; do
         # package generates documentation, then it will
         # overwrite the GH pages archive with that dir only
         echo 'Generating documentation...'
-        npm run docs
+        npm run docs || exit 1
         mv docs "../.docs/${dir}"
         # Reset the readme file to the default
         echo "${readme}" > README.md

--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -52,6 +52,14 @@ for dir in */ ; do
     echo 'Running tests...'
     npm test || exit 1
     if "${publish}" ; then
+        # Determine latest published version on the registry
+        npm_version="$(npm --silent v "${package_name}" version)"
+        echo "Version on NPM = ${npm_version}"
+        if [[ "${local_version}" != "${npm_version}" ]] ; then
+            # When publishing, we need to overwrite the
+            # package date with the current timestamp
+            package_date=$(date +%s)
+        fi
         # Store current readme content, copy over the
         # template readme file, and replace variables
         echo 'Generating readme...'
@@ -63,17 +71,11 @@ for dir in */ ; do
         sed -i "s:%VER%:${local_version//':'/';'}:g" README.md
         sed -i "s:%TIME%:${package_date//':'/';'}:g" README.md
         echo "${readme}" >> README.md
-        # Determine latest published version on the registry
-        npm_version="$(npm --silent v "${package_name}" version)"
-        echo "Version on NPM = ${npm_version}"
         if [[ "${local_version}" == "${npm_version}" ]] ; then
             echo 'Skipping publish step'
         else
             echo 'Publishing...'
             npm publish
-            # When publishing, we need to overwrite the
-            # package date with the current timestamp
-            package_date=$(date +%s)
         fi
         # Always generate documentation because if only one
         # package generates documentation, then it will


### PR DESCRIPTION
Currently, the last updated date will not update on the same workflow when a package is published. Also, the template is not included in the readme in npm. This PR fixes those 2 issues.