### PR TITLE
Smath v1.5.0

### DIFF
--- a/smath/CHANGELOG.md
+++ b/smath/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.5.0
+
+- Change spread syntax parameters to a single array parameter
+- Update `exray` dependency version
+- Update tsdoc examples
+- Fix bug in `factorial()`
+- Write tests for new functions
+- Add all missing functions to `npx`
+
 ## 1.4.0
 
 - Add `error()` function

--- a/smath/examples/package.json
+++ b/smath/examples/package.json
@@ -3,6 +3,6 @@
     "clean": "rm -rf node_modules package-lock.json"
   },
   "dependencies": {
-    "smath": "file:smath-1.4.0.tgz"
+    "smath": "file:smath-1.5.0.tgz"
   }
 }

--- a/smath/package.json
+++ b/smath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smath",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Small math function library",
   "homepage": "https://npm.nicfv.com/smath",
   "bin": "dist/bin.js",

--- a/smath/package.json
+++ b/smath/package.json
@@ -48,7 +48,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "20.11.30",
-    "exray": "1.0.1",
+    "exray": "1.0.2",
     "typedoc": "0.25.12",
     "typescript": "5.4.3"
   }

--- a/smath/src/bin.ts
+++ b/smath/src/bin.ts
@@ -2,32 +2,18 @@
 
 import { SMath } from '.';
 
-const args: Array<string> = process.argv.slice(2);
-
-/**
- * Try to convert an argument into a numeric value.
- */
-function N(index: number, defaultVal: number = NaN): number {
-    if (index >= args.length) {
-        if (Number.isFinite(defaultVal)) {
-            return defaultVal;
+const func: string = process.argv[2].toLowerCase(),
+    nums: Array<number> = process.argv.slice(3).map((arg, i) => {
+        const num: number = Number.parseFloat(arg);
+        if (Number.isFinite(num)) {
+            return num;
         } else {
-            console.error('Required argument ' + index + ' is missing!');
+            console.error('Argument #' + i + ' is "' + arg + '" but a number was expected.');
             process.exit(1);
         }
-    }
-    const arg: number = Number.parseFloat(args[index]);
-    if (Number.isFinite(arg)) {
-        return arg;
-    } else if (Number.isFinite(defaultVal)) {
-        return defaultVal;
-    } else {
-        console.error('Argument #' + index + ' is ' + arg + ' but a number was expected.');
-        process.exit(1);
-    }
-}
+    });
 
-if (args.length < 1 || args[0].includes('help')) {
+if (func.includes('help')) {
     console.log('Key: <required> [optional]');
     console.log('Arguments:');
     console.log('  help                     : Show this page');
@@ -42,56 +28,48 @@ if (args.length < 1 || args[0].includes('help')) {
     console.log('  translate <n> <min1> <max1> <min2> <max2>');
     console.log('                           : Linearly interpolate `n` from `min1`, `max1` to `min2`, `max2`');
     console.log('  error <exp> <act>        : Calculate the normaized percent error between `exp` and `act`');
-    process.exit(1);
+    // process.exit(1);
 }
 
-switch (args[0]) {
+switch (func) {
     case ('avg'): {
-        if (args.length < 2) {
-            console.error('Need at least 1 argument.');
-            process.exit(1);
-        }
-        const operands: Array<number> = [];
-        for (let i = 1; i < args.length; i++) {
-            operands.push(N(i));
-        }
-        console.log(SMath.avg(operands));
+        console.log(SMath.avg(nums));
         break;
     }
     case ('approx'): {
-        console.log(SMath.approx(N(1), N(2), N(3, 1e-6)));
+        console.log(SMath.approx(nums[0], nums[1], nums[2] ?? 1e-6));
         break;
     }
     case ('clamp'): {
-        console.log(SMath.clamp(N(1), N(2), N(3)));
+        console.log(SMath.clamp(nums[0], nums[1], nums[2]));
         break;
     }
     case ('expand'): {
-        console.log(SMath.expand(N(1), N(2), N(3)));
+        console.log(SMath.expand(nums[0], nums[1], nums[2]));
         break;
     }
     case ('linspace'): {
-        console.log(SMath.linspace(N(1), N(2), N(3)));
+        console.log(SMath.linspace(nums[0], nums[1], nums[2]));
         break;
     }
     case ('logspace'): {
-        console.log(SMath.logspace(N(1), N(2), N(3)));
+        console.log(SMath.logspace(nums[0], nums[1], nums[2]));
         break;
     }
     case ('normalize'): {
-        console.log(SMath.normalize(N(1), N(2), N(3)));
+        console.log(SMath.normalize(nums[0], nums[1], nums[2]));
         break;
     }
     case ('translate'): {
-        console.log(SMath.translate(N(1), N(2), N(3), N(4), N(5)));
+        console.log(SMath.translate(nums[0], nums[1], nums[2], nums[3], nums[4]));
         break;
     }
     case ('error'): {
-        console.log(SMath.error(N(1), N(2)));
+        console.log(SMath.error(nums[0], nums[1]));
         break;
     }
     default: {
-        console.error('Unknown argument "' + args[0] + '". Use with "help" for a list of commands.');
+        console.error('Unknown argument "' + func + '". Use with "help" for a list of commands.');
         process.exit(1);
     }
 }

--- a/smath/src/bin.ts
+++ b/smath/src/bin.ts
@@ -31,8 +31,8 @@ if (args.length < 1 || args[0].includes('help')) {
     console.log('Key: <required> [optional]');
     console.log('Arguments:');
     console.log('  help                     : Show this page');
-    console.log('  approx <a> <b> [eps]     : Check if `a` and `b` are approximately equal');
     console.log('  avg <c0> [c1] ... [cn]   : Take an average of `n` numbers');
+    console.log('  approx <a> <b> [eps]     : Check if `a` and `b` are approximately equal');
     console.log('  clamp <n> <min> <max>    : Clamp `n` between `min` and `max`');
     console.log('  expand <n> <min> <max>   : Expand normalized `n` between `min` and `max`');
     console.log('  linspace <min> <max> <n> : Generate `n` linearly spaced numbers between `min` and `max`');
@@ -46,10 +46,6 @@ if (args.length < 1 || args[0].includes('help')) {
 }
 
 switch (args[0]) {
-    case ('approx'): {
-        console.log(SMath.approx(N(1), N(2), N(3, 1e-6)));
-        break;
-    }
     case ('avg'): {
         if (args.length < 2) {
             console.error('Need at least 1 argument.');
@@ -60,6 +56,10 @@ switch (args[0]) {
             operands.push(N(i));
         }
         console.log(SMath.avg(operands));
+        break;
+    }
+    case ('approx'): {
+        console.log(SMath.approx(N(1), N(2), N(3, 1e-6)));
         break;
     }
     case ('clamp'): {

--- a/smath/src/bin.ts
+++ b/smath/src/bin.ts
@@ -17,7 +17,11 @@ if (func.includes('help')) {
     console.log('Key: <required> [optional]');
     console.log('Arguments:');
     console.log('  help                     : Show this page');
+    console.log('  sum <c0> [c1] ... [cn]   : Compute a total of `n` numbers');
+    console.log('  prod <c0> [c1] ... [cn]  : Compute a product of `n` numbers');
     console.log('  avg <c0> [c1] ... [cn]   : Take an average of `n` numbers');
+    console.log('  varp <c0> [c1] ... [cn]  : Compute the population variance of `n` numbers');
+    console.log('  vars <c0> [c1] ... [cn]  : Compute the sample variance of `n` numbers');
     console.log('  approx <a> <b> [eps]     : Check if `a` and `b` are approximately equal');
     console.log('  clamp <n> <min> <max>    : Clamp `n` between `min` and `max`');
     console.log('  expand <n> <min> <max>   : Expand normalized `n` between `min` and `max`');
@@ -27,13 +31,30 @@ if (func.includes('help')) {
     console.log('                           : Normalize `n` between `min` and `max`');
     console.log('  translate <n> <min1> <max1> <min2> <max2>');
     console.log('                           : Linearly interpolate `n` from `min1`, `max1` to `min2`, `max2`');
+    console.log('  factorial <n>            : Compute `n!` (factorial)');
     console.log('  error <exp> <act>        : Calculate the normaized percent error between `exp` and `act`');
-    // process.exit(1);
+    process.exit(1);
 }
 
 switch (func) {
+    case ('sum'): {
+        console.log(SMath.sum(nums));
+        break;
+    }
+    case ('prod'): {
+        console.log(SMath.prod(nums));
+        break;
+    }
     case ('avg'): {
         console.log(SMath.avg(nums));
+        break;
+    }
+    case ('varp'): {
+        console.log(SMath.varp(nums));
+        break;
+    }
+    case ('vars'): {
+        console.log(SMath.vars(nums));
         break;
     }
     case ('approx'): {
@@ -62,6 +83,10 @@ switch (func) {
     }
     case ('translate'): {
         console.log(SMath.translate(nums[0], nums[1], nums[2], nums[3], nums[4]));
+        break;
+    }
+    case ('factorial'): {
+        console.log(SMath.factorial(nums[0]));
         break;
     }
     case ('error'): {

--- a/smath/src/bin.ts
+++ b/smath/src/bin.ts
@@ -59,7 +59,7 @@ switch (args[0]) {
         for (let i = 1; i < args.length; i++) {
             operands.push(N(i));
         }
-        console.log(SMath.avg(...operands));
+        console.log(SMath.avg(operands));
         break;
     }
     case ('clamp'): {

--- a/smath/src/index.ts
+++ b/smath/src/index.ts
@@ -56,7 +56,7 @@ export abstract class SMath {
      * const pvar = SMath.pvar(1, 2, 3, 4); // 1.25
      * ```
      */
-    public static pvar(n: Array<number>): number {
+    public static varp(n: Array<number>): number {
         const mean: number = this.avg(n),
             squares: Array<number> = n.map(x => (x - mean) ** 2);
         return this.sum(squares) / n.length;
@@ -70,7 +70,7 @@ export abstract class SMath {
      * const svar = SMath.svar(1, 2, 3, 4); // 1.666...
      * ```
      */
-    public static svar(n: Array<number>): number {
+    public static vars(n: Array<number>): number {
         const mean: number = this.avg(n),
             squares: Array<number> = n.map(x => (x - mean) ** 2);
         return this.sum(squares) / (n.length - 1);

--- a/smath/src/index.ts
+++ b/smath/src/index.ts
@@ -16,7 +16,7 @@ export abstract class SMath {
      * @returns The sum total
      * @example
      * ```js
-     * const sum = SMath.sum(1, 2, 3); // 6
+     * const y = SMath.sum([1, 2, 3]); // 6
      * ```
      */
     public static sum(n: Array<number>): number {
@@ -29,7 +29,7 @@ export abstract class SMath {
      * @returns The product
      * @example
      * ```js
-     * const prod = SMath.prod(2, 2, 3, 5); // 60
+     * const y = SMath.prod([2, 2, 3, 5]); // 60
      * ```
      */
     public static prod(n: Array<number>): number {
@@ -41,7 +41,7 @@ export abstract class SMath {
      * @returns The average, or mean
      * @example
      * ```js
-     * const mean = SMath.avg(1, 2, 3, 4); // 2.5
+     * const y = SMath.avg([1, 2, 4, 4]); // 2.75
      * ```
      */
     public static avg(n: Array<number>): number {
@@ -53,7 +53,7 @@ export abstract class SMath {
      * @returns The population variance
      * @example
      * ```js
-     * const pvar = SMath.pvar(1, 2, 3, 4); // 1.25
+     * const y = SMath.varp([1, 2, 4, 4]); // 1.6875
      * ```
      */
     public static varp(n: Array<number>): number {
@@ -67,7 +67,7 @@ export abstract class SMath {
      * @returns The sample variance
      * @example
      * ```js
-     * const svar = SMath.svar(1, 2, 3, 4); // 1.666...
+     * const y = SMath.vars([1, 2, 4, 4]); // 2.25
      * ```
      */
     public static vars(n: Array<number>): number {
@@ -199,7 +199,7 @@ export abstract class SMath {
      * @returns `n!`
      * @example
      * ```js
-     * const factorial = SMath.factorial(5); // 120
+     * const y = SMath.factorial(5); // 120
      * ```
      */
     public static factorial(n: number): number {
@@ -225,7 +225,7 @@ export abstract class SMath {
      * @returns The relative (normalized) error
      * @example
      * ```js
-     * const error = SMath.error(22.5, 25); // -0.1
+     * const e = SMath.error(22.5, 25); // -0.1
      * ```
      */
     public static error(experimental: number, actual: number): number {

--- a/smath/src/index.ts
+++ b/smath/src/index.ts
@@ -19,7 +19,7 @@ export abstract class SMath {
      * const sum = SMath.sum(1, 2, 3); // 6
      * ```
      */
-    public static sum(...n: Array<number>): number {
+    public static sum(n: Array<number>): number {
         return n.reduce((a, b) => a + b, 0);
     }
     /**
@@ -32,7 +32,7 @@ export abstract class SMath {
      * const prod = SMath.prod(2, 2, 3, 5); // 60
      * ```
      */
-    public static prod(...n: Array<number>): number {
+    public static prod(n: Array<number>): number {
         return n.reduce((a, b) => a * b, 1);
     }
     /**
@@ -44,8 +44,8 @@ export abstract class SMath {
      * const mean = SMath.avg(1, 2, 3, 4); // 2.5
      * ```
      */
-    public static avg(...n: Array<number>): number {
-        return this.sum(...n) / n.length;
+    public static avg(n: Array<number>): number {
+        return this.sum(n) / n.length;
     }
     /**
      * Compute the variance of a **complete population**.
@@ -56,10 +56,10 @@ export abstract class SMath {
      * const pvar = SMath.pvar(1, 2, 3, 4); // 1.25
      * ```
      */
-    public static pvar(...n: Array<number>): number {
-        const mean: number = this.avg(...n),
+    public static pvar(n: Array<number>): number {
+        const mean: number = this.avg(n),
             squares: Array<number> = n.map(x => (x - mean) ** 2);
-        return this.sum(...squares) / n.length;
+        return this.sum(squares) / n.length;
     }
     /**
      * Compute the variance of a **sample**.
@@ -70,10 +70,10 @@ export abstract class SMath {
      * const svar = SMath.svar(1, 2, 3, 4); // 1.666...
      * ```
      */
-    public static svar(...n: Array<number>): number {
-        const mean: number = this.avg(...n),
+    public static svar(n: Array<number>): number {
+        const mean: number = this.avg(n),
             squares: Array<number> = n.map(x => (x - mean) ** 2);
-        return this.sum(...squares) / (n.length - 1);
+        return this.sum(squares) / (n.length - 1);
     }
     /**
      * Clamp a number within a range.
@@ -206,7 +206,7 @@ export abstract class SMath {
         if (n < 0 || (n | 0) !== n) {
             throw new Error('Input must be a positive integer.');
         } else if (n === 0) {
-            return 0;
+            return 1;
         } else if (n <= 2) {
             return n;
         } else {

--- a/smath/src/index.ts
+++ b/smath/src/index.ts
@@ -76,6 +76,21 @@ export abstract class SMath {
         return this.sum(squares) / (n.length - 1);
     }
     /**
+     * Check if two numbers are approximately equal with a maximum abolute error.
+     * @param a Any number
+     * @param b Any number
+     * @param epsilon Maximum absolute error
+     * @returns True if `a` is approximately `b`
+     * @example
+     * ```js
+     * const b1 = SMath.approx(1 / 3, 0.33, 1e-6), // false
+     *       b2 = SMath.approx(1 / 3, 0.33, 1e-2); // true
+     * ```
+     */
+    public static approx(a: number, b: number, epsilon: number = 1e-6): boolean {
+        return a - b < epsilon && b - a < epsilon;
+    }
+    /**
      * Clamp a number within a range.
      * @param n The number to clamp
      * @param min The minimum value of the range
@@ -95,21 +110,6 @@ export abstract class SMath {
             return max;
         }
         return n;
-    }
-    /**
-     * Check if two numbers are approximately equal with a maximum abolute error.
-     * @param a Any number
-     * @param b Any number
-     * @param epsilon Maximum absolute error
-     * @returns True if `a` is approximately `b`
-     * @example
-     * ```js
-     * const b1 = SMath.approx(1 / 3, 0.33, 1e-6), // false
-     *       b2 = SMath.approx(1 / 3, 0.33, 1e-2); // true
-     * ```
-     */
-    public static approx(a: number, b: number, epsilon: number = 1e-6): boolean {
-        return a - b < epsilon && b - a < epsilon;
     }
     /**
      * Normalize the number `n` from the range `min, max` to the range `0, 1`

--- a/smath/src/test.ts
+++ b/smath/src/test.ts
@@ -22,14 +22,14 @@ X.eq(SMath.avg([1, 2, 3, 4]), 2.5);
 const ds1: Array<number> = [1, 2, 3, 4],
     ds2: Array<number> = [-3, 0, 1, 1, 2];
 
-X.eq(SMath.pvar(ds1), 1.25);
-X.gt(SMath.pvar(ds2), 2.95); // 2.96
-X.lt(SMath.pvar(ds2), 2.97);
+X.eq(SMath.varp(ds1), 1.25);
+X.gt(SMath.varp(ds2), 2.95); // 2.96
+X.lt(SMath.varp(ds2), 2.97);
 
-X.gt(SMath.svar(ds1), 1.66); // 1.666...
-X.lt(SMath.svar(ds1), 1.67);
-X.gt(SMath.svar(ds2), 3.69); // 3.7
-X.lt(SMath.svar(ds2), 3.71);
+X.gt(SMath.vars(ds1), 1.66); // 1.666...
+X.lt(SMath.vars(ds1), 1.67);
+X.gt(SMath.vars(ds2), 3.69); // 3.7
+X.lt(SMath.vars(ds2), 3.71);
 
 X.true(SMath.approx(0.1 + 0.2, 0.3));
 X.true(SMath.approx(0.3 - 0.1, 0.2));

--- a/smath/src/test.ts
+++ b/smath/src/test.ts
@@ -1,26 +1,35 @@
 import { SMath } from './index';
 import { X } from 'exray';
 
-X.eq(SMath.sum(), 0);
-X.eq(SMath.sum(1), 1);
-X.eq(SMath.sum(1, 2), 3);
-X.eq(SMath.sum(1, 2, 3), 6);
-X.eq(SMath.sum(1, 2, 3, 4), 10);
+X.eq(SMath.sum([]), 0);
+X.eq(SMath.sum([1]), 1);
+X.eq(SMath.sum([1, 2]), 3);
+X.eq(SMath.sum([1, 2, 3]), 6);
+X.eq(SMath.sum([1, 2, 3, 4]), 10);
 
-X.eq(SMath.prod(), 1);
-X.eq(SMath.prod(1), 1);
-X.eq(SMath.prod(1, 2), 2);
-X.eq(SMath.prod(1, 2, 3), 6);
-X.eq(SMath.prod(1, 2, 3, 4), 24);
+X.eq(SMath.prod([]), 1);
+X.eq(SMath.prod([1]), 1);
+X.eq(SMath.prod([1, 2]), 2);
+X.eq(SMath.prod([1, 2, 3]), 6);
+X.eq(SMath.prod([1, 2, 3, 4]), 24);
 
-X.eq(SMath.avg(1), 1);
-X.eq(SMath.avg(1, 2), 1.5);
-X.eq(SMath.avg(1, 2, 3), 2);
-X.eq(SMath.avg(1, 2, 3, 4), 2.5);
+X.is(SMath.avg([]).toString(), 'NaN');
+X.eq(SMath.avg([1]), 1);
+X.eq(SMath.avg([1, 2]), 1.5);
+X.eq(SMath.avg([1, 2, 3]), 2);
+X.eq(SMath.avg([1, 2, 3, 4]), 2.5);
 
-X.gt(SMath.svar(1, 2, 3, 4), 1.66); // 1.666...
-X.lt(SMath.svar(1, 2, 3, 4), 1.67);
-X.eq(SMath.pvar(1, 2, 3, 4), 1.25);
+const ds1: Array<number> = [1, 2, 3, 4],
+    ds2: Array<number> = [-3, 0, 1, 1, 2];
+
+X.eq(SMath.pvar(ds1), 1.25);
+X.gt(SMath.pvar(ds2), 2.95); // 2.96
+X.lt(SMath.pvar(ds2), 2.97);
+
+X.gt(SMath.svar(ds1), 1.66); // 1.666...
+X.lt(SMath.svar(ds1), 1.67);
+X.gt(SMath.svar(ds2), 3.69); // 3.7
+X.lt(SMath.svar(ds2), 3.71);
 
 X.true(SMath.approx(0.1 + 0.2, 0.3));
 X.true(SMath.approx(0.3 - 0.1, 0.2));
@@ -63,6 +72,13 @@ X.gt(SMath.logspace(0, 2, 5)[3], 31.622); // Approx 31.6227766...
 X.lt(SMath.logspace(0, 2, 5)[3], 31.623);
 X.is(SMath.logspace(2, -2, 5).join(), '100,10,1,0.1,0.01');
 X.is(SMath.logspace(0, 0, -1).join(), '');
+
+X.eq(SMath.factorial(0), 1);
+X.eq(SMath.factorial(1), 1);
+X.eq(SMath.factorial(2), 2);
+X.eq(SMath.factorial(3), 6);
+X.eq(SMath.factorial(4), 24);
+X.eq(SMath.factorial(5), 120);
 
 X.eq(SMath.error(9, 10), -0.1);
 X.eq(SMath.error(11, 10), 0.1);


### PR DESCRIPTION
SMath is now using array syntax - not spread syntax - for "dataset-related" function parameters. (e.g. `sum`, `varp`, ...)

- Closes #87 
- Closes #88 
- Closes #89 