### PR TITLE
Idea #1 (bad)

### DIFF
--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -25,6 +25,8 @@ if [[ "${1}" == 'publish' ]] ; then
             }
             # Set working directory to package directory
             cd "${dir}" || exit 1
+            # Remove "-local" from package version
+            sed -i 's/\("version".*:.*[0-9]\+\.[0-9]\+\.[0-9]\+\)-local"/\1"/' package.json
             # Extract package name, changelog version, and package version
             package_name="$(npm --silent v ./ name)"
             echo "Package Name   = ${package_name}"

--- a/packages/datafit/package.json
+++ b/packages/datafit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datafit",
-  "version": "1.4.7",
+  "version": "1.4.7-local",
   "description": "Simple curve-fitting algorithm",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",
@@ -49,9 +49,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.0"
+    "smath": "1.9.1"
   },
   "devDependencies": {
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }

--- a/packages/smath/package.json
+++ b/packages/smath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smath",
-  "version": "1.9.1",
+  "version": "1.9.1-local",
   "description": "Small math function library",
   "homepage": "https://npm.nicfv.com/",
   "bin": "dist/bin.js",
@@ -56,6 +56,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "22.10.1",
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }

--- a/packages/t6/package.json
+++ b/packages/t6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t6",
-  "version": "1.1.6",
+  "version": "1.1.6-local",
   "description": "Lightweight assertion testing framework",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",

--- a/packages/viridis/package.json
+++ b/packages/viridis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viridis",
-  "version": "1.1.6",
+  "version": "1.1.6-local",
   "description": "Color gradients for data visualization",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",
@@ -41,9 +41,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.0"
+    "smath": "1.9.1"
   },
   "devDependencies": {
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }


### PR DESCRIPTION
Adds `-local` at the end of local package versions, which makes it so that `npm` has to install the remote packages.