### PR TITLE
Idea #2 (Good)

### DIFF
--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -40,7 +40,7 @@ if [[ "${1}" == 'publish' ]] ; then
                 echo 'Package and changelog versions do not match!'
                 exit 1
             fi
-            # Generate package and run all examples
+            # Run all examples and generate output
             cd examples && {
                 npm i || exit 1
                 for example in * ; do

--- a/.github/workflows/run
+++ b/.github/workflows/run
@@ -5,7 +5,7 @@ node -v || exit 1
 npm -v || exit 1
 
 # Run tests on ci workflow
-npm run clean && npm i && npm test || exit 1
+npm start || exit 1
 
 # Check for and set npm token if publish flag is set
 if [[ "${1}" == 'publish' ]] ; then
@@ -41,8 +41,6 @@ if [[ "${1}" == 'publish' ]] ; then
                 exit 1
             fi
             # Generate package and run all examples
-            echo 'Generating tarball...'
-            npm pack --pack-destination examples || exit 1
             cd examples && {
                 npm i || exit 1
                 for example in * ; do
@@ -74,8 +72,7 @@ if [[ "${1}" == 'publish' ]] ; then
                         echo "Skipping file ${example}"
                     fi
                 done
-                # Clean the project and reset the working directory
-                npm run clean || exit 1
+                # Reset the working directory
                 cd ..
             } || exit 1
             # Make sure that the local version number is higher before publishing

--- a/.github/workflows/scripts
+++ b/.github/workflows/scripts
@@ -1,26 +1,3 @@
 #!/usr/bin/env bash
 
-clean=false
-build=false
-pack=false
-
-while getopts ':cbp' opt ; do
-    case "${opt}" in
-        'c') clean=true ;;
-        'b') build=true ;;
-        'p') pack=true ;;
-        *) echo "Invalid option ${OPTARG}" && exit 1 ;;
-    esac
-done
-
-if "${build}" ; then
-    tsc && node dist/test.js && rm dist/test.js types/test.d.ts
-fi
-
-if "${pack}" ; then
-    npm pack --pack-destination examples
-fi
-
-if "${clean}" ; then
-    rm -rf dist types
-fi
+rm -rf dist types && tsc && node dist/test.js && rm dist/test.js types/test.d.ts && npm pack --pack-destination examples

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "clean": "rm -rf packages/*/node_modules node_modules package-lock.json docs && npm run postpack --workspaces"
   },
   "workspaces": [
+    "packages/t6",
+    "packages/smath",
     "packages/*"
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "npm i && tsc -v && npm start --workspaces",
-    "stop": "rm -rf packages/*/node_modules packages/*/dist packages/*/types node_modules package-lock.json docs",
+    "stop": "rm -rf packages/*/node_modules packages/*/dist packages/*/types packages/*/examples/*.tgz node_modules package-lock.json docs",
     "docs": "typedoc --version && typedoc"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "typedoc": "0.27.2",
+    "typedoc": "0.27.3",
     "typescript": "5.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "scripts": {
-    "build": "npm run build --workspaces",
-    "test": "tsc -v && npm test --workspaces",
-    "docs": "typedoc",
-    "clean": "rm -rf packages/*/node_modules node_modules package-lock.json docs && npm run postpack --workspaces"
+    "start": "npm i && tsc -v && npm start --workspaces",
+    "stop": "rm -rf packages/*/node_modules packages/*/dist packages/*/types node_modules package-lock.json docs",
+    "docs": "typedoc --version && typedoc"
   },
   "workspaces": [
     "packages/t6",

--- a/packages/datafit/CHANGELOG.md
+++ b/packages/datafit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.8
+
+- This version is functionally identical to the previous, but is published as a test of the updated workflow, with a cleaned up `package.json` file
+
 ## 1.4.7
 
 - Update typescript dependency version to 5.7.2

--- a/packages/datafit/package.json
+++ b/packages/datafit/package.json
@@ -11,10 +11,7 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run postpack && tsc && node dist/test.js && rm dist/test.js types/test.d.ts",
-    "test": "tsc --noEmit",
-    "prepack": "npm run build",
-    "postpack": "rm -rf dist types"
+    "start": "../../.github/workflows/scripts"
   },
   "keywords": [
     "math",

--- a/packages/datafit/package.json
+++ b/packages/datafit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datafit",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Simple curve-fitting algorithm",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",
@@ -46,9 +46,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.1"
+    "smath": "1.9.2"
   },
   "devDependencies": {
-    "t6": "1.1.6"
+    "t6": "1.1.7"
   }
 }

--- a/packages/datafit/package.json
+++ b/packages/datafit/package.json
@@ -49,9 +49,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.0"
+    "smath": "1.9.1"
   },
   "devDependencies": {
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }

--- a/packages/dimensional/package.json
+++ b/packages/dimensional/package.json
@@ -11,10 +11,7 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run postpack && tsc && node dist/test.js && rm dist/test.js types/test.d.ts",
-    "test": "tsc --noEmit",
-    "prepack": "npm run build",
-    "postpack": "rm -rf dist types"
+    "start": "../../.github/workflows/scripts"
   },
   "keywords": [
     "quantity",

--- a/packages/smath/CHANGELOG.md
+++ b/packages/smath/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.2
+
+- This version is functionally identical to the previous, but is published as a test of the updated workflow, with a cleaned up `package.json` file
+
 ## 1.9.1
 
 - Publish with provenance

--- a/packages/smath/package.json
+++ b/packages/smath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smath",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Small math function library",
   "homepage": "https://npm.nicfv.com/",
   "bin": "dist/bin.js",
@@ -53,6 +53,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "22.10.1",
-    "t6": "1.1.6"
+    "t6": "1.1.7"
   }
 }

--- a/packages/smath/package.json
+++ b/packages/smath/package.json
@@ -11,10 +11,7 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run postpack && tsc && node dist/test.js && rm dist/test.js types/test.d.ts",
-    "test": "tsc --noEmit",
-    "prepack": "npm run build",
-    "postpack": "rm -rf dist types"
+    "start": "../../.github/workflows/scripts"
   },
   "keywords": [
     "small",

--- a/packages/smath/package.json
+++ b/packages/smath/package.json
@@ -56,6 +56,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "22.10.1",
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }

--- a/packages/t6/CHANGELOG.md
+++ b/packages/t6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.7
+
+- This version is functionally identical to the previous, but is published as a test of the updated workflow, with a cleaned up `package.json` file
+
 ## 1.1.6
 
 - Update typescript dependency version to 5.7.2

--- a/packages/t6/package.json
+++ b/packages/t6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t6",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Lightweight assertion testing framework",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",

--- a/packages/t6/package.json
+++ b/packages/t6/package.json
@@ -11,10 +11,7 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run postpack && tsc && node dist/test.js && rm dist/test.js types/test.d.ts",
-    "test": "tsc --noEmit",
-    "prepack": "npm run build",
-    "postpack": "rm -rf dist types"
+    "start": "../../.github/workflows/scripts"
   },
   "keywords": [
     "except",

--- a/packages/viridis/CHANGELOG.md
+++ b/packages/viridis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.7
+
+- This version is functionally identical to the previous, but is published as a test of the updated workflow, with a cleaned up `package.json` file
+
 ## 1.1.6
 
 - Update typescript dependency version to 5.7.2

--- a/packages/viridis/package.json
+++ b/packages/viridis/package.json
@@ -11,10 +11,7 @@
     "types"
   ],
   "scripts": {
-    "build": "npm run postpack && tsc && node dist/test.js && rm dist/test.js types/test.d.ts",
-    "test": "tsc --noEmit",
-    "prepack": "npm run build",
-    "postpack": "rm -rf dist types"
+    "start": "../../.github/workflows/scripts"
   },
   "keywords": [
     "color",

--- a/packages/viridis/package.json
+++ b/packages/viridis/package.json
@@ -41,9 +41,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.0"
+    "smath": "1.9.1"
   },
   "devDependencies": {
-    "t6": "1.1.5"
+    "t6": "1.1.6"
   }
 }

--- a/packages/viridis/package.json
+++ b/packages/viridis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viridis",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Color gradients for data visualization",
   "homepage": "https://npm.nicfv.com/",
   "bin": "",
@@ -38,9 +38,9 @@
   "repository": "github:nicfv/npm",
   "license": "MIT",
   "dependencies": {
-    "smath": "1.9.1"
+    "smath": "1.9.2"
   },
   "devDependencies": {
-    "t6": "1.1.6"
+    "t6": "1.1.7"
   }
 }


### PR DESCRIPTION
In this one, I simply add a "build order" by specifying some of the workspaces to be operated on first, in `./package.json`

It still bugs me a bit that I have to do it explicitly, and `npm` doesn't figure it out on its own. I'm not a fan either that it's preferring the local versions over the published ones, but at least this way I'd be able to publish >1 package version in one PR.