### PR TITLE
Psychart Legend

### DIFF
--- a/packages/psychart/src/psychart.ts
+++ b/packages/psychart/src/psychart.ts
@@ -582,7 +582,8 @@ export class Psychart {
             return;
         }
         // Determine whether this is time-dependent.
-        const timeSeries: boolean = Number.isFinite(options.time.now) && Number.isFinite(options.time.end) && Number.isFinite(options.time.start);
+        const hasTimeStamp: boolean = Number.isFinite(options.time.now),
+            timeSeries: boolean = hasTimeStamp && Number.isFinite(options.time.end) && Number.isFinite(options.time.start);
         // Divide by 100 if relHumType is set to 'percent'
         if (state.measurement === 'dbrh' && options.relHumType === 'percent') {
             state.other /= 100;
@@ -612,7 +613,7 @@ export class Psychart {
         const pointName: string = (options.legend && options.name ? options.legend + ': ' + options.name : options.legend + options.name);
         // Generate the text to display on mouse hover.
         const tooltipString: string = (pointName ? pointName + '\n' : '') +
-            (timeSeries ? new Date(tNow).toLocaleString() + '\n' : '') +
+            (hasTimeStamp ? new Date(tNow).toLocaleString() + '\n' : '') +
             currentState.db.toFixed(1) + this.units.temp + ' Dry Bulb\n' +
             (currentState.rh * 100).toFixed() + '% Rel. Hum.\n' +
             currentState.wb.toFixed(1) + this.units.temp + ' Wet Bulb\n' +


### PR DESCRIPTION
- Closes #162 
- Closes #160 

A timestamp can be shown using the `time.now` property, without providing a `start` and `end` time. This will use the color from the `color` property. The gradient is only used when `start`, `end`, and `now` timestamps are all provided.

Example to show a solid-color point with timestamp:

```js
ps.plot(
    {
        db: 25,
        other: 15,
        measurement: 'dbwb',
    },
    {
        time: { now: new Date().getTime() },
        color: '#009090',
    });
```

<img width="186" alt="Screenshot 2025-03-29 at 12 10 01" src="https://github.com/user-attachments/assets/87bf7c5a-6c03-45c6-8c45-aa49872623ab" />
